### PR TITLE
Update main.cpp

### DIFF
--- a/state-machine/main.cpp
+++ b/state-machine/main.cpp
@@ -400,7 +400,7 @@ public:
         void handle(void (E::*event)(A1,A2), A1 a1, A2 a2, const char *name) {
             handle(EventWith2Args2<E,A1,A2>(event, a1, a2, name));
         }
-        virtual void handle( Event f ) = 0;
+        virtual void handle( Event f ) {};
     };
 };
 


### PR DESCRIPTION
Allow the constructions of objects of a type such as:
struct Event_Proxy : Events_To_Proxy {}
where Events_To_Proxy inherit from EventInterface

This way a proxy pattern so that Event_Proxy can send the events to the right state machine can be achieved
